### PR TITLE
Allow `npm run develop` to make project accessible on local network

### DIFF
--- a/bin/marqueestatic
+++ b/bin/marqueestatic
@@ -7,6 +7,8 @@ program
     .option('-p, --production', 'Build for production (minify)')
     .option('-f, --force', 'Force the action, overriding checks and guards')
     .option('-c, --configuration <name>', 'A configuration to use')
+    .option('--host <host>', 'Set the development server host, eg 0.0.0.0 for external access (default `localhost`)')
+    .option('--port <port>', 'Set the development server port (default `5000`)')
     .option('--use-cache', 'Cache API responses (for development)')
     .parse(process.argv);
 
@@ -25,6 +27,8 @@ function continueCommand(payload) {
         configuration: program.configuration || null,
         production: program.production || false,
         use_cache: program.useCache || false,
+        host: program.host || 'localhost',
+        port: program.port || '5000',
         payload: payload,
     }
 

--- a/development/develop.coffee
+++ b/development/develop.coffee
@@ -6,5 +6,8 @@ startWatcher    = require './watcher'
 module.exports = (project_directory, options) ->
 
     build_directory = runCompilation project_directory, options, (files, assets, project_package, project_config) ->
-        startServer('0.0.0.0', 5000, build_directory)
+        host = options.host
+        port = parseInt(options.port)
+        port = 5000 unless port
+        startServer(host, port, build_directory)
         startWatcher(project_directory, build_directory, options, project_config)


### PR DESCRIPTION
By using `0.0.0.0` instead of `localhost`, other users on a local network can view projects in development by navigating to the hostname of the development machine in the browser (ex. `http://crm114.local:5000`).
