### PR TITLE
Add optional `media` prop to <Asset> component

### DIFF
--- a/base/Asset.cjsx
+++ b/base/Asset.cjsx
@@ -22,6 +22,7 @@ _render = (props) =>
                 rel     = 'stylesheet'
                 type    = 'text/css'
                 href    = full_path
+                media   = props.media
             />
         else
             console.warn("Asset got unknown asset type (#{ _ext })")
@@ -66,6 +67,9 @@ module.exports = React.createClass
         path    : React.PropTypes.string.isRequired
         async   : React.PropTypes.bool
         inline  : React.PropTypes.bool
+        media   : React.PropTypes.string
+    getDefaultPropts: ->
+        media   : 'screen'
     render: ->
         if @props.inline
             return _renderInline(@props)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marquee-static-sdk",
-  "version": "0.6.0-alpha.16",
+  "version": "0.6.0-alpha.17",
   "scripts": {
     "test": "npm run clearbuild && npm run build:source && jest",
     "prepublish": "npm test && npm run clearbuild && npm run build",


### PR DESCRIPTION
This PR enables you to use the `<Asset>` component to serve up alternative stylesheets.