### PR TITLE
Feature/add target prop to card

### DIFF
--- a/components/Card.cjsx
+++ b/components/Card.cjsx
@@ -16,6 +16,7 @@ Card = React.createClass
         link        : React.PropTypes.string
         id          : React.PropTypes.string
         title       : React.PropTypes.string
+        target      : React.PropTypes.string
         className   : React.PropTypes.oneOfType([
                 React.PropTypes.string
                 React.PropTypes.object
@@ -34,8 +35,8 @@ Card = React.createClass
             className   : "Card #{ @props.className or '' } #{ variants }"
             href        : @props.link
             title       : @props.title
+            target      : if @props.link then @props.target or '_self' else null
         , @props.children
-
 
 
 module.exports = Card

--- a/components/Card.cjsx
+++ b/components/Card.cjsx
@@ -35,7 +35,7 @@ Card = React.createClass
             className   : "Card #{ @props.className or '' } #{ variants }"
             href        : @props.link
             title       : @props.title
-            target      : if @props.link then @props.target or '_self' else null
+            target      : @props.target
         , @props.children
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "scripts": {
     "test": "npm run clearbuild && npm run build:source && jest",
     "prepublish": "npm run clearbuild && npm run build",


### PR DESCRIPTION
If the `<Card>` has a `link` prop passed to it, it will also accept an optional `target` prop. If `link` is set but `target` is not, the component will render with `target="_self"`.